### PR TITLE
Syncing files are unnecessary

### DIFF
--- a/snapshot.go
+++ b/snapshot.go
@@ -99,11 +99,7 @@ func NewWithSealer(logger log.Logger, r *raft.Raft, sealer Sealer) (*Snapshot, e
 		return nil, fmt.Errorf("failed to compress snapshot file: %v", err)
 	}
 
-	// Sync the compressed file and rewind it so it's ready to be streamed
-	// out by the caller.
-	if err := archive.Sync(); err != nil {
-		return nil, fmt.Errorf("failed to sync snapshot: %v", err)
-	}
+	// rewind it so it's ready to be streamed out by the caller.
 	if _, err := archive.Seek(0, 0); err != nil {
 		return nil, fmt.Errorf("failed to rewind snapshot: %v", err)
 	}
@@ -238,11 +234,7 @@ func WriteToTempFileWithSealer(logger log.Logger, in io.Reader, metadata *raft.S
 		return nil, nil, fmt.Errorf("failed to read snapshot file: %v", err)
 	}
 
-	// Sync and rewind the file so it's ready to be read again.
-	if err := snap.Sync(); err != nil {
-		cleanupFunc()
-		return nil, nil, fmt.Errorf("failed to sync temp snapshot: %v", err)
-	}
+	// Rewind the file so it's ready to be read again.
 	if _, err := snap.Seek(0, 0); err != nil {
 		cleanupFunc()
 		return nil, nil, fmt.Errorf("failed to rewind temp snapshot: %v", err)


### PR DESCRIPTION
We don't need to sync files in either snapshot save or restore, as
snapshot operations are aborted upon a crash recovery, and sync calls
are unnecessary overhead in normal times.

When saving snapshots, the case is trivial. The API is
non-side-effecting to Raft state, and upon crash recovery, the
API call is aborted and temporary file is irrelevant and ignored.

The restore path also doesn't require an sync call.  The restore
method here creates a temporary file to capture the snapshot archive
file, validates it, and then immediately passes the temporary file
(untouched) to Raft function, which creates yet another temp file[1].
Upon a crash recovery, the temporary file created by raft-snapshot is
ignored, and thus irrelevant.

The raft library manages the file it created differently without relying
on fsync.  On recovery, the raft library examines all snapshots
(including partial ones being created while crashing), and validates
them properly, before relying on them.

[1] https://github.com/hashicorp/raft/blob/v1.1.0/raft.go#L930-L960