### PR TITLE
[SECVULN-23532] Pin GitHub Actions in the Two-Stage PR Review Process workflow using SHAs as opposed to versions

### DIFF
--- a/.github/workflows/two-step-pr-approval.yml
+++ b/.github/workflows/two-step-pr-approval.yml
@@ -14,7 +14,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       
       - name: Two stage PR review
-        uses: hashicorp/two-stage-pr-approval@v0.1.0
+        uses: hashicorp/two-stage-pr-approval@c68d868f2e0def603bbcf4e7c3e20ebbd1c04934


### PR DESCRIPTION
Does what it says on the tin.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.

Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

If you have any questions, please contact your direct supervisor, GRC (#team-grc), or the PCI working group (#proj-pci-reboot). You can also find more information at [PCI Compliance](https://hashicorp.atlassian.net/wiki/spaces/SEC/pages/2784559202/PCI+Compliance).
